### PR TITLE
(PE-5653) Correctly proxy non-GET methods

### DIFF
--- a/src/puppetlabs/ring_middleware/common.clj
+++ b/src/puppetlabs/ring_middleware/common.clj
@@ -9,17 +9,3 @@
   (let [prepare #(-> (update-in % [1 :expires] str)
                      (update-in [1] dissoc :domain :secure))]
     (assoc resp :cookies (into {} (map prepare (:cookies resp))))))
-
-(defn slurp-binary
-  "Reads len bytes from InputStream is and returns a byte array."
-  [^java.io.InputStream is len]
-  (with-open [rdr is]
-    (let [buf (byte-array len)]
-      (.read rdr buf)
-      buf)))
-
-(defn http-get
-  ([url]
-   (http-get url {:as :text}))
-  ([url options]
-   (http-client/get url options)))

--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -2,7 +2,7 @@
   (:require [ring.middleware.cookies :refer [wrap-cookies]]
             [clojure.string :refer [join split]]
             [puppetlabs.http.client.sync :refer [request]]
-            [puppetlabs.ring-middleware.common :refer [prepare-cookies slurp-binary]])
+            [puppetlabs.ring-middleware.common :refer [prepare-cookies]])
   (:import (java.net URI)))
 
 (defn wrap-proxy
@@ -22,8 +22,10 @@
           (-> (merge {:method (:request-method req)
                       :url (str remote-uri "?" (:query-string req))
                       :headers (dissoc (:headers req) "host" "content-length")
-                      :body (if-let [len (get-in req [:headers "content-length"])]
-                              (slurp-binary (:body req) (Integer/parseInt len)))
+                      :body (let [body (slurp (:body req))]
+                              (if-not (empty? body)
+                                body
+                                nil))
                       :as :stream} http-opts)
               request
               prepare-cookies))

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -4,14 +4,19 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.ring-middleware.core :refer [wrap-proxy]]))
+            [puppetlabs.ring-middleware.core :refer [wrap-proxy]]
+            [puppetlabs.http.client.sync :as http-client]))
+
+(defn post-target-handler
+  [req]
+  (if (= (:request-method req) :post)
+    {:status 200 :body (slurp (:body req))}
+    {:status 404 :body "D'oh"}))
 
 (defn proxy-target-handler
   [req]
   (condp = (:uri req)
-    "/hello/world" {:status 200 :body (str "Hello, World!"
-                                        ((:headers req) "x-fancy-proxy-header")
-                                        ((:headers req) "cookie"))}
+    "/hello/world" {:status 200 :body (str "Hello, World!")}
     {:status 404 :body "D'oh"}))
 
 (defn proxy-error-handler
@@ -31,7 +36,11 @@
        (add-ring-handler
          target-webserver#
          proxy-target-handler
-         "/hello"))
+         "/hello")
+       (add-ring-handler
+         target-webserver#
+         post-target-handler
+         "/hello/post/"))
        (with-app-with-config proxy-app#
          [jetty9-service]
          {:webserver ~proxy}
@@ -47,9 +56,14 @@
        :proxy         {:host "0.0.0.0"
                        :port 10000}
        :proxy-handler proxy-wrapped-app}
-      (let [response (http-get "http://localhost:9000/hello/world")]
+      (let [response (http-client/get "http://localhost:9000/hello/world" {:as :text})]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get "http://localhost:10000/hello-proxy/world")]
+      (let [response (http-client/get "http://localhost:10000/hello-proxy/world" {:as :text})]
         (is (= (:status response) 200))
-        (is (= (:body response) "Hello, World!"))))))
+        (is (= (:body response) "Hello, World!")))
+      (let [response (http-client/get "http://localhost:10000/hello-proxy/world" {:as :stream})]
+        (is (= (slurp (:body response)) "Hello, World!")))
+      (let [response (http-client/post "http://localhost:10000/hello-proxy/post/" {:as :stream :body "I'm posted!"})]
+        (is (= (:status response) 200))
+        (is (= (slurp (:body response)) "I'm posted!"))))))


### PR DESCRIPTION
Some code we brought across from the original ring-proxy seemed to be
specifically for clj-http, and it was causing POST/PUT requests to
fail. This commit removes that code and standardises on `slurp`'ing the
incoming request body before sending it to the proxied server.
