### PR TITLE
(maint) Allow DELETE requests with a body to be proxied

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,4 +21,5 @@
                                   [puppetlabs/trapperkeeper "0.5.0" :classifier "test" :scope "test"
                                    :exclusions [prismatic/schema clj-time]]
                                   [puppetlabs/kitchensink "0.7.2" :classifier "test" :scope "test"
-                                   :exclusions [clj-time commons-io]]]}})
+                                   :exclusions [clj-time commons-io]]
+                                  [clj-http "1.0.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]]}})

--- a/src/puppetlabs/ring_middleware/common.clj
+++ b/src/puppetlabs/ring_middleware/common.clj
@@ -11,3 +11,13 @@
   (let [prepare #(-> (update-in % [1 :expires] str)
                      (update-in [1] dissoc :domain :secure))]
     (assoc resp :cookies (into {} (map prepare (:cookies resp))))))
+
+; DELETE requests with a body are technically not allowed, and blow up our HTTP client, so filter them out
+(defn prepare-body
+  [req]
+  (if (= (:request-method req) :delete)
+    nil
+    (let [body (slurp (:body req))]
+      (if-not (empty? body)
+        body
+        nil))))

--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -2,7 +2,7 @@
   (:require [ring.middleware.cookies :refer [wrap-cookies]]
             [clojure.string :refer [join split]]
             [puppetlabs.http.client.sync :refer [request]]
-            [puppetlabs.ring-middleware.common :refer [prepare-cookies]])
+            [puppetlabs.ring-middleware.common :refer [prepare-cookies prepare-body]])
   (:import (java.net URI)))
 
 (defn wrap-proxy
@@ -22,14 +22,12 @@
                                (str (.getPath uri)
                                     (subs (:uri req) (.length proxied-path)))
                                nil
-                               nil)]
+                               nil)
+              request-body (prepare-body req)]
           (-> (merge {:method (:request-method req)
                       :url (str remote-uri "?" (:query-string req))
                       :headers (dissoc (:headers req) "host" "content-length")
-                      :body (let [body (slurp (:body req))]
-                              (if-not (empty? body)
-                                body
-                                nil))
+                      :body request-body
                       :as :stream
                       :force-redirects true
                       :decompress-body false} http-opts)

--- a/test/puppetlabs/ring_middleware/common_test.clj
+++ b/test/puppetlabs/ring_middleware/common_test.clj
@@ -1,0 +1,14 @@
+(ns puppetlabs.ring-middleware.common-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.ring-middleware.common :refer :all]))
+
+(defn make-string-inputstream [string]
+  (java.io.ByteArrayInputStream. (.getBytes string "UTF-8")))
+
+(deftest prepare-body-test
+  (testing "when the request is a DELETE"
+    (is (= (prepare-body {:request-method :delete}) nil)))
+  (testing "when the body is a stream with content"
+    (is (= (prepare-body {:body (make-string-inputstream "I am a body")}) "I am a body")))
+  (testing "when the body is a stream without content")
+    (is (= (prepare-body {:body (make-string-inputstream "")}) nil)))


### PR DESCRIPTION
Technically DELETE requests shouldn't send a body, however browsers and
some clients allow you to do so. Our HTTP client doesn't handle these
deletes so filter them out when proxying.
