### PR TITLE
(PE-5860) Add regex support to wrap-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ to a remote URL specified by the `remote-uri-base` argument.
 The arguments are as follows:
 
 * `handler`: A ring-handler that will be used if the provided url does not begin with the proxied-path prefix
-* `proxied-path`: The URL prefix of all requests that are to be proxied
+* `proxied-path`: The URL prefix of all requests that are to be proxied. This can be either a string or a
+   regular expression pattern.
 * `remote-uri-base`: The base URL that you want to proxy requests with the `proxied-path` prefix to
 * `http-opts`: An optional list of options for an http client. This is used by the handler returned by
   `wrap-proxy` when it makes a proxied request to a remote URI. For a list of available options, please

--- a/project.clj
+++ b/project.clj
@@ -21,4 +21,5 @@
                                   [puppetlabs/trapperkeeper "0.5.0" :classifier "test" :scope "test"
                                    :exclusions [prismatic/schema clj-time]]
                                   [puppetlabs/kitchensink "0.7.2" :classifier "test" :scope "test"
-                                   :exclusions [clj-time commons-io]]]}})
+                                   :exclusions [clj-time commons-io]]
+                                  [compojure "1.1.8"]]}})

--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.ring-middleware.core
   (:require [ring.middleware.cookies :refer [wrap-cookies]]
-            [clojure.string :refer [join split]]
+            [clojure.string :refer [join split replace-first]]
             [clojure.tools.logging :as log]
             [puppetlabs.http.client.sync :refer [request]]
             [puppetlabs.ring-middleware.common :refer [prepare-cookies]])
@@ -9,10 +9,11 @@
 (defn wrap-proxy
   "Proxies requests to proxied-path, a local URI, to the remote URI at
   remote-uri-base, also a string."
-  [handler ^String proxied-path remote-uri-base & [http-opts]]
+  [handler proxied-path remote-uri-base & [http-opts]]
   (wrap-cookies
     (fn [req]
-      (if (.startsWith ^String (:uri req) (str proxied-path "/"))
+      (if (or (and (instance? String proxied-path) (.startsWith ^String (:uri req) (str proxied-path "/")))
+              (and (instance? java.util.regex.Pattern proxied-path) (re-matches proxied-path (:uri req))))
         ; Remove :decompress-body from the options map, as if this is
         ; ever set to true, the response returned to the client making the
         ; proxy request will be truncated
@@ -21,7 +22,7 @@
               remote-uri (URI. (.getScheme uri)
                                (.getAuthority uri)
                                (str (.getPath uri)
-                                    (subs (:uri req) (.length proxied-path)))
+                                    (replace-first (:uri req) proxied-path ""))
                                nil
                                nil)
               response (-> (merge {:method (:request-method req)


### PR DESCRIPTION
Modify wrap-proxy so that the proxied-path variable can be
either a string or a regular expression pattern.
