### PR TITLE
PE-5845 NC - Creating a group with diacritical marks (áéíóúäëïöüñçâê) 

### DIFF
--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -27,10 +27,9 @@
               response (-> (merge {:method (:request-method req)
                                    :url (str remote-uri "?" (:query-string req))
                                    :headers (dissoc (:headers req) "host" "content-length")
-                                   :body (let [body (slurp (:body req))]
-                                           (if-not (empty? body)
-                                             body
-                                             nil))
+                                   :body (if (contains? #{:patch :post :put} (:request-method req))
+                                           (:body req)
+                                           nil)
                                    :as :stream
                                    :force-redirects true
                                    :decompress-body false} http-opts)


### PR DESCRIPTION
Diacritics not displaying properly

There was unnecessary (slurp) call which converts stream resource to Java string.
And somewhere in this conversion diacritics is lost. This patch makes it so that
request body is not touched at all. Instead of asking for empty body, we are asking
for desired HTTP request method and comparing it with list of officially supported
HTTP methods in http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/methods/HttpEntityEnclosingRequestBase.html
