### PR TITLE
(TK-228) Change redirect default

### DIFF
--- a/src/puppetlabs/ring_middleware/common.clj
+++ b/src/puppetlabs/ring_middleware/common.clj
@@ -42,7 +42,8 @@
                              :headers         (dissoc (:headers req) "host" "content-length")
                              :body            (not-empty (slurp (:body req)))
                              :as              :stream
-                             :force-redirects true
+                             :force-redirects false
+                             :follow-redirects false
                              :decompress-body false}
                             http-opts)
                      request


### PR DESCRIPTION
Previously, ring-middleware would follow all redirects by default
on the proxy-side when a proxy response was returned by whatever
was being proxied to. Change this so that by default the
proxy will not follow redirects unless explicitly told to.