### PR TITLE
(maint) Move helpers to utils namespace

### DIFF
--- a/src/puppetlabs/ring_middleware/utils.clj
+++ b/src/puppetlabs/ring_middleware/utils.clj
@@ -1,0 +1,93 @@
+(ns puppetlabs.ring-middleware.utils
+  (:require [schema.core :as schema]
+            [ring.util.response :as rr]
+            [slingshot.slingshot :as sling]
+            [cheshire.core :as json])
+  (:import (java.security.cert X509Certificate)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Schemas
+
+(def ResponseType
+  (schema/enum :json :plain))
+
+(def RingRequest
+  {:uri schema/Str
+   (schema/optional-key :ssl-client-cert) (schema/maybe X509Certificate)
+   schema/Keyword schema/Any})
+
+(def RingResponse
+  {:status schema/Int
+   :headers {schema/Str schema/Any}
+   :body schema/Any
+   schema/Keyword schema/Any})
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Helpers
+
+(schema/defn ^:always-validate json-response
+  :- RingResponse
+  [status :- schema/Int
+   body :- schema/Any]
+  (-> body
+      json/encode
+      rr/response
+      (rr/status status)
+      (rr/content-type "application/json; charset=utf-8")))
+
+(schema/defn ^:always-validate plain-response
+  :- RingResponse
+  [status :- schema/Int
+   body :- schema/Str]
+  (-> body
+      rr/response
+      (rr/status status)
+      (rr/content-type "text/plain; charset=utf-8")))
+
+(defn throw-bad-request!
+  "Throw a :bad-request type slingshot error with the supplied message"
+  [message]
+  (sling/throw+  {:kind :bad-request
+                  :msg message}))
+
+(defn bad-request?
+  [e]
+  "Determine if the supplied slingshot error is for a bad request"
+  (when (map? e)
+    (= (:kind e)
+       :bad-request)))
+
+(defn throw-service-unavailable!
+  "Throw a :service-unavailable type slingshot error with the supplied message"
+  [message]
+  (sling/throw+  {:kind :service-unavailable
+                  :msg message}))
+
+(defn service-unavailable?
+  [e]
+  "Determine if the supplied slingshot error is for an unavailable service"
+  (when  (map? e)
+    (= (:kind e)
+       :service-unavailable)))
+
+(defn throw-data-invalid!
+  "Throw a :data-invalid type slingshot error with the supplied message"
+  [message]
+  (sling/throw+  {:kind :data-invalid
+                  :msg message}))
+
+(defn data-invalid?
+  [e]
+  "Determine if the supplied slingshot error is for invalid data"
+  (when  (map? e)
+    (= (:kind e)
+       :data-invalid)))
+
+(defn schema-error?
+  [e]
+  "Determine if the supplied slingshot error is for a schema mismatch"
+  (when (map? e)
+    (= (:type e)
+       :schema.core/error)))
+

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -5,6 +5,7 @@
             [compojure.handler :as handler]
             [compojure.route :as route]
             [puppetlabs.ring-middleware.core :as core]
+            [puppetlabs.ring-middleware.utils :as utils]
             [puppetlabs.ring-middleware.testutils.common :refer :all]
             [puppetlabs.ssl-utils.core :refer [pem->cert]]
             [puppetlabs.ssl-utils.simple :as ssl-simple]
@@ -149,27 +150,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Core Helpers
-
-(deftest json-response-test
-  (testing "json response"
-    (let [source {:key 1}
-          response (core/json-response 200 source)]
-      (testing "has 200 status code"
-        (is (= 200 (:status response))))
-      (testing "has json content-type"
-        (is (re-matches #"application/json.*" (get-in response [:headers "Content-Type"]))))
-      (testing "is properly converted to a json string"
-        (is (= 1 ((json/parse-string (:body response)) "key")))))))
-
-(deftest plain-response-test
-  (testing "json response"
-    (let [message "Response message"
-          response (core/plain-response 200 message)]
-      (testing "has 200 status code"
-        (is (= 200 (:status response))))
-      (testing "has plain content-type"
-        (is (re-matches #"text/plain.*" (get-in response [:headers "Content-Type"])))))))
-
 
 (deftest sanitize-client-cert-test
   (testing "sanitize-client-cert"
@@ -575,7 +555,7 @@
             (is (= (name error) (get json-body "kind")))))))
     (testing "handles errors thrown by `throw-data-invalid!`"
       (logutils/with-test-logging
-        (let [stack (core/wrap-data-errors (fn [_] (core/throw-data-invalid! "Error Message")))
+        (let [stack (core/wrap-data-errors (fn [_] (utils/throw-data-invalid! "Error Message")))
               response (stack (basic-request))
               json-body (json/parse-string (response :body))]
           (is (= 400 (response :status)))
@@ -591,7 +571,7 @@
   (testing "wrap-bad-request"
     (testing "default behavior"
       (logutils/with-test-logging
-        (let [stack (core/wrap-bad-request (fn [_] (core/throw-bad-request! "Error Message")))
+        (let [stack (core/wrap-bad-request (fn [_] (utils/throw-bad-request! "Error Message")))
               response (stack (basic-request))
               json-body (json/parse-string (response :body))]
           (is (= 400 (response :status)))
@@ -600,7 +580,7 @@
           (is (= "bad-request" (get json-body "kind"))))))
     (testing "can be plain text"
       (logutils/with-test-logging
-        (let [stack (core/wrap-bad-request (fn [_] (core/throw-bad-request! "Error Message")) :plain)
+        (let [stack (core/wrap-bad-request (fn [_] (utils/throw-bad-request! "Error Message")) :plain)
               response (stack (basic-request))]
           (is (re-matches #"text/plain.*" (get-in response [:headers "Content-Type"]))))))))
 
@@ -625,7 +605,7 @@
   (testing "wrap-service-unavailable"
     (testing "default behavior"
       (logutils/with-test-logging
-        (let [stack (core/wrap-service-unavailable (fn [_] (core/throw-service-unavailable! "Test Service is DOWN!")))
+        (let [stack (core/wrap-service-unavailable (fn [_] (utils/throw-service-unavailable! "Test Service is DOWN!")))
               response (stack (basic-request))
               json-body (json/parse-string (response :body))]
           (is (= 503 (response :status)))
@@ -634,7 +614,7 @@
           (is (= "service-unavailable" (get json-body "kind"))))))
     (testing "can be plain text"
       (logutils/with-test-logging
-        (let [stack (core/wrap-service-unavailable (fn [_] (core/throw-service-unavailable! "Test Service is DOWN!")) :plain)
+        (let [stack (core/wrap-service-unavailable (fn [_] (utils/throw-service-unavailable! "Test Service is DOWN!")) :plain)
               response (stack (basic-request))]
           (is (re-matches #"text/plain.*" (get-in response [:headers "Content-Type"]))))))))
 

--- a/test/puppetlabs/ring_middleware/utils_test.clj
+++ b/test/puppetlabs/ring_middleware/utils_test.clj
@@ -1,0 +1,25 @@
+(ns puppetlabs.ring-middleware.utils-test
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
+            [puppetlabs.ring-middleware.utils :as utils]))
+
+(deftest json-response-test
+  (testing "json response"
+    (let [source {:key 1}
+          response (utils/json-response 200 source)]
+      (testing "has 200 status code"
+        (is (= 200 (:status response))))
+      (testing "has json content-type"
+        (is (re-matches #"application/json.*" (get-in response [:headers "Content-Type"]))))
+      (testing "is properly converted to a json string"
+        (is (= 1 ((json/parse-string (:body response)) "key")))))))
+
+(deftest plain-response-test
+  (testing "json response"
+    (let [message "Response message"
+          response (utils/plain-response 200 message)]
+      (testing "has 200 status code"
+        (is (= 200 (:status response))))
+      (testing "has plain content-type"
+        (is (re-matches #"text/plain.*" (get-in response [:headers "Content-Type"])))))))
+


### PR DESCRIPTION
Previously we included middleware and utility methods all in the core
namespace.

This was awkward for consumers as they often only need one or the other.

This duplicates out all of the public utility functions into a utils
namespace, sets the core functions to depend on the them, and updates
the test accordingly. It leaves the existing implementations in the core
namespace so that consumers can upgrade components without having to
move in lockstep.