### PR TITLE
(PE-16075) (PE-15848) Add i18n libraries and externalize strings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,14 +17,15 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [ring "1.4.0"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 [puppetlabs/i18n "0.4.1"]]
 
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :plugins [[lein-release "1.0.5"]]
+  :plugins [[puppetlabs/i18n "0.4.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/src/puppetlabs/ring_middleware/common.clj
+++ b/src/puppetlabs/ring_middleware/common.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.ring-middleware.common
   (:require [clojure.tools.logging :as log]
             [clojure.string :refer [join split replace-first]]
-            [puppetlabs.http.client.sync :refer [request]])
+            [puppetlabs.http.client.sync :refer [request]]
+            [puppetlabs.i18n.core :as i18n :refer [trs]])
   (:import (java.net URI)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -48,6 +49,5 @@
                             http-opts)
                      request
                      prepare-cookies)]
-    (log/debug "Proxying request to" (:uri req) "to remote url" (str remote-uri)
-               ". Remote server responded with status" (:status response))
+    (log/debug (trs "Proxying request to {0} to remote url {1}. Remote server responded with status {2}" (:uri req) (str remote-uri) (:status response)))
     response))


### PR DESCRIPTION
- Add i18n libraries
- Externalize strings
- Add only one makefile since this is the auto-generated one with the ">&" typo, there is no need to worry about the second makefile because no PACKAGES variable is needed for this repo
- Add comments to the Makefile for details on the typo/PR open for the fix