### PR TITLE
(TK-430) Migrate to clj-parent 0.3.3 and bump i18n to 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
 - oraclejdk7
 - openjdk7

--- a/project.clj
+++ b/project.clj
@@ -1,31 +1,28 @@
-(def clj-version "1.7.0")
-(def ks-version "1.3.0")
-(def tk-version "1.3.1")
-
 (defproject puppetlabs/ring-middleware "1.0.1-SNAPSHOT"
-  :dependencies [[org.clojure/clojure ~clj-version]
+  :dependencies [[org.clojure/clojure]
+                 [org.clojure/tools.logging]
+                 [cheshire]
+                 [prismatic/schema]
+                 [ring/ring-core]
+                 [slingshot]
 
-                 ;; begin version conflict resolution dependencies
-                 [clj-time "0.11.0"]
-                 ;; end version conflict resolution dependencies
+                 [puppetlabs/http-client]
+                 [puppetlabs/kitchensink]
+                 [puppetlabs/ssl-utils]
+                 [puppetlabs/i18n]]
 
-                 [cheshire "5.6.1"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [prismatic/schema "1.1.0"]
+  :min-lein-version "2.7.1"
 
-                 [puppetlabs/http-client "0.5.0"]
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/ssl-utils "0.8.1"]
-                 [ring "1.4.0"]
-                 [slingshot "0.12.2"]
-                 [puppetlabs/i18n "0.4.1"]]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.3"]
+                   :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :plugins [[puppetlabs/i18n "0.4.1"]]
+  :plugins [[lein-parent "0.3.1"]
+            [puppetlabs/i18n "0.6.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
@@ -33,13 +30,7 @@
                                      :sign-releases false}]
                         ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
 
-  :profiles {:dev {:dependencies [
-                                  ;; begin version conflict resolution dependencies
-                                  [org.clojure/tools.reader "1.0.0-beta1"]
-                                  [org.clojure/tools.macro "0.1.5"]
-                                  ;; begin version conflict resolution dependencies
-
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.5"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
-                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
-                                  [compojure "1.5.0"]]}})
+  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]
+                                  [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
+                                  [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
+                                  [compojure]]}})

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -626,7 +626,7 @@
               response (stack (basic-request))
               json-body (json/parse-string (response :body))]
           (is (= 500 (response :status)))
-          (is (logged? #".*Internal Server Error.*" :warn))
+          (is (logged? #".*Internal Server Error.*" :error))
           (is (re-matches #"Internal Server Error.*" (get json-body "msg" ""))))))
     (testing "can be plain text"
       (logutils/with-test-logging

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -38,7 +38,9 @@
   ([subject method uri]
    {:request-method method
     :uri uri
-    :ssl-client-cert (:cert (ssl-simple/gen-self-signed-cert subject 1))
+    :ssl-client-cert (:cert (ssl-simple/gen-self-signed-cert subject
+                                                             1
+                                                             {:keylength 512}))
     :authorization {:certificate "foo"}}))
 
 (defn post-target-handler
@@ -139,7 +141,7 @@
        (add-ring-handler
         target-webserver#
         post-target-handler
-        "/hello/post/"))
+        "/hello/post"))
      (with-app-with-config proxy-app#
        [jetty9-service]
        {:webserver ~proxy}


### PR DESCRIPTION
This PR migrates ring-middleware to using clj-parent version 0.3.3 for its
dependencies.  This commit also updates the i18n plugin dependency from 0.4.1
to 0.6.0 for compatibility with the version of i18n being inherited from
clj-parent.  This commit also upgrades the lein version to 2.7.1 in the
.travis.yml file since 2.7.1 is the minimum version required for
compatibility with lein/clj-parent.

This PR also includes a few minor test improvements with allow for the tests
to run more quickly and avoid the generation of some warning messages.