### PR TITLE
(PE-28653) Add new nosniff and Content-Security-Policy wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,27 @@ A utility middleware with the following signature:
 
 This middleware adds `X-Frame-Options: DENY` headers to requests if they are handled by the handler.
 
+### wrap-add-x-content-nosniff
+
+A utility middleware with the following signature:
+
+```clj
+(wrap-add-x-content-nosniff handler)
+```
+
+This middleware adds `X-Content-Type-Options: nosniff` headers to requests if they are handled by the handler.
+
+### wrap-add-csp
+
+A utility middleware with the following signature:
+
+```clj
+(wrap-add-csp handler csp-val)
+```
+
+This middleware adds `Content-Security-Policy` headers to requests if they are handled by the handler.
+The value of the header will be equivalent to the second argument passed, `csp-val`.
+
 ### wrap-data-errors
 ```clj
 (wrap-data-errors handler)

--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -92,6 +92,23 @@
       (when response
         (assoc-in response [:headers "X-Frame-Options"] "DENY")))))
 
+(schema/defn ^:always-validate wrap-add-x-content-nosniff :- IFn
+  "Adds 'X-Content-Type-Options: nosniff' headers to request."
+  [handler :- IFn]
+  (fn [request]
+    (let [response (handler request)]
+      (when response
+        (assoc-in response [:headers "X-Content-Type-Options"] "nosniff")))))
+
+(schema/defn ^:always-validate wrap-add-csp :- IFn
+  "Adds 'Content-Security-Policy: default-src 'self'' headers to request."
+  [handler :- IFn
+   csp-val]
+  (fn [request]
+    (let [response (handler request)]
+      (when response
+        (assoc-in response [:headers "Content-Security-Policy"] csp-val)))))
+
 (schema/defn ^:always-validate wrap-with-certificate-cn :- IFn
   "Ring middleware that will annotate the request with an
   :ssl-client-cn key representing the CN contained in the client


### PR DESCRIPTION
This commit adds two new wrappers, one for the purpose of adding `X-Content-Type-Options: nosniff` headers, and one that adds a `Content-Security-Policy` header with a custom-supplied value.