### PR TITLE
(PE-28642) update changelog to note new wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.0
+* This version adds two new middleware used in other
+  puppetlabs projects, documented in the [README](./README.md):
+  * `wrap-add-x-content-nosniff`
+  * `wrap-add-csp`
+
+
 # 1.0.1
 * This is a bug fix release that ensure stacktraces are correctly printed
   to the log when handling otherwise uncaught exceptions.


### PR DESCRIPTION
This commit updates the changelog in preparation for a release containing the new wrappers added in cc74a872c0d2308a0ab133059fa3f2abb1ee64ed