### PR TITLE
(PE-30229) update caching headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+* This version updates the `wrap-add-cache-headers` middleware so that
+  it adds a `cache-control` header with the "no-store" directive instead of
+  the "private, max-age=0, no-cache" directives.
+
 # 1.2.0
 * This version adds `wrap-params` middleware with custom implementation of the
   `params-request` function. This was copied from the puppetserver repo to this

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A utility middleware with the following signature:
 (wrap-add-cache-headers handler)
 ```
 
-This middleware adds `cache-control` headers ("private, max-age=0, no-cache") to `GET` and `PUT` requests if they are handled by the handler.
+This middleware adds `Cache-Control: no-store` headers to `GET` and `PUT` requests if they are handled by the handler.
 
 ### wrap-add-x-frame-options-deny
 

--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -81,7 +81,7 @@
         (if (or
              (= request-method :get)
              (= request-method :put))
-          (assoc-in response [:headers "cache-control"] "private, max-age=0, no-cache")
+          (assoc-in response [:headers "cache-control"] "no-store")
           response)))))
 
 (schema/defn ^:always-validate wrap-add-x-frame-options-deny :- IFn

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -441,7 +441,7 @@
         get-request     {:request-method :get}
         post-request    {:request-method :post}
         delete-request  {:request-method :delete}
-        no-cache-header "private, max-age=0, no-cache"]
+        no-cache-header "no-store"]
     (testing "wrap-add-cache-headers ignores nil response"
       (let [handler (constantly nil)
             wrapped-handler (core/wrap-add-cache-headers handler)]


### PR DESCRIPTION
This updates the `wrap-add-cache-headers` middleware so that it adds a `cache-control` header
with the "no-store" directive instead of the previously-used "private, max-age=0, no-cache" directives.
    
The previous directives are out of date, as the "no-store" directive is now the only directive needed
to prevent cached responses on modern browsers.
    
Tests, the README, and the CHANGELOG are all updated to account for this change and prepare for a new release.