### PR TITLE
(PE-32624): Ring-middleware: create wrapper

### DIFF
--- a/src/puppetlabs/ring_middleware/core.clj
+++ b/src/puppetlabs/ring_middleware/core.clj
@@ -234,3 +234,11 @@
                    (catch Exception e
                      (response e)))))))
 
+(schema/defn ^:always-validate wrap-add-referrer-policy :- IFn
+  "Adds referrer policy to the header as 'Referrer-Policy: no-referrer' or 'Referrer-Policy: same-origin'"
+  [policy-option :- schema/Str
+   handler :- IFn]
+  (fn [request]
+    (let [response (handler request)]
+      (when-not (nil? response)
+        (assoc-in response [:headers "Referrer-Policy"] policy-option)))))


### PR DESCRIPTION
This commit adds a wrapper to include a referrer-policy in the header and
adds tests to verify the header is updated.