### PR TITLE
(PE-36363) Update repo to use Jetty 10, remove unversioned dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0
+
+* This version updates testing in the repo to use trapperkeeper-webserver-jetty10. The repo
+  is now intended to be used with Jetty 10.
+
 # 1.3.0
 * This version updates the `wrap-add-cache-headers` middleware so that
   it adds a `cache-control` header with the "no-store" directive instead of

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project was originally adapted from tailrecursion's
 [ring-proxy](https://github.com/tailrecursion/ring-proxy) middleware, and is
-meant for use with the [Trapperkeeper Jetty9 Webservice](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9).  It also contains common ring middleware between Puppet projects and helpers to be used with the middleware.
+meant for use with the [Trapperkeeper Jetty10 Webservice](https://github.com/puppetlabs/trapperkeeper-webserver-jetty10).  It also contains common ring middleware between Puppet projects and helpers to be used with the middleware.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,19 +1,9 @@
-(defproject puppetlabs/ring-middleware "1.3.2-SNAPSHOT"
-  :dependencies [[org.clojure/clojure]
-                 [org.clojure/tools.logging]
-                 [cheshire]
-                 [prismatic/schema]
-                 [ring/ring-core]
-                 [slingshot]
-
-                 [puppetlabs/http-client]
-                 [puppetlabs/kitchensink]
-                 [puppetlabs/ssl-utils]
-                 [puppetlabs/i18n]]
+(defproject puppetlabs/ring-middleware "2.0.0-SNAPSHOT"
+  :dependencies [[cheshire]]
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "7.0.1"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -21,7 +11,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :plugins [[lein-parent "0.3.1"]
+  :plugins [[lein-parent "0.3.7"]
             [puppetlabs/i18n "0.7.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
@@ -30,7 +20,8 @@
                                      :sign-releases false}]
                         ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
 
-  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]
+  :profiles {:dev {:dependencies [[com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.1"]
+                                  [org.bouncycastle/bcpkix-jdk15on]
                                   [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                   [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
                                   [compojure]]}})

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -10,7 +10,7 @@
             [puppetlabs.ssl-utils.core :refer [pem->cert]]
             [puppetlabs.ssl-utils.simple :as ssl-simple]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer :all]
+            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [ring.util.response :as rr]
@@ -127,7 +127,7 @@
 (defmacro with-target-and-proxy-servers
   [{:keys [target proxy proxy-handler ring-handler endpoint target-endpoint]} & body]
   `(with-app-with-config proxy-target-app#
-     [jetty9-service]
+     [jetty10-service]
      {:webserver ~target}
      (let [target-webserver# (get-service proxy-target-app# :WebserverService)]
        (add-ring-handler
@@ -143,7 +143,7 @@
         post-target-handler
         "/hello/post"))
      (with-app-with-config proxy-app#
-       [jetty9-service]
+       [jetty10-service]
        {:webserver ~proxy}
        (let [proxy-webserver# (get-service proxy-app# :WebserverService)]
          (add-ring-handler proxy-webserver# ~proxy-handler ~endpoint))


### PR DESCRIPTION
Updates repo to use Jetty10, there is a warning encountered in the tests I started to address in 
https://github.com/puppetlabs/trapperkeeper-webserver-jetty10/pull/11 but since it doesn't seem to affect the core functionality I'm going to leave it for a subsequent release in the interest of getting the rest of the PRs up.

```
2023-07-06 14:29:48,650 WARN  [o.e.j.s.h.ContextHandler] Unimplemented getRequestCharacterEncoding() - use org.eclipse.jetty.servlet.ServletContextHandler

lein test puppetlabs.ring-middleware.utils-test

Ran 17 tests containing 174 assertions.
0 failures, 0 errors.
```

Removes most unversioned dependencies in this repo, preferring the versioning of clj-parent.