### PR TITLE
(PE-36484) Bump tk-jetty to address Jetty ring-handler broken function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1
+* Updates tk-jetty-10 to 1.0.7 which includes a fix for ring handler's getRequestCharacterEncoding() function.
+
 # 2.0.0
 
 * This version updates testing in the repo to use trapperkeeper-webserver-jetty10. The repo

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                                      :sign-releases false}]
                         ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
 
-  :profiles {:dev {:dependencies [[com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.1"]
+  :profiles {:dev {:dependencies [[com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.7"]
                                   [org.bouncycastle/bcpkix-jdk15on]
                                   [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                   [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]


### PR DESCRIPTION
Ran 17 tests containing 174 assertions.
0 failures, 0 errors.