### PR TITLE
(PE-38702) add method and uri to unhandled exception logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.0.2
+# 2.0.4
+* add calling method and uri to unhandled exception logging
+# 2.0.3 
+* released with no changes due to issues with licensing in project.clj
+# 2.0.2 - unreleased
 * update to clj parent 7.3.31
 * optimize the `wrap-uncaught-errors` to avoid anonymous functions, and ensure streams are closed
 * add new wrappers: 


### PR DESCRIPTION
This adds the calling method and the URI to the `wrap-uncaught-errors` handler which will provide more context when an unhandled exception is being generated.